### PR TITLE
JUnit 5.10.2 -> 5.14.4 バージョンアップ（sample-app-vuejs）

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -91,8 +91,10 @@ dependencies {
 	runtimeOnly 'org.glassfish.expressly:expressly:5.0.0'
 
 	testImplementation 'org.iplass:iplass-test'
-	testImplementation platform('org.junit:junit-bom:5.10.2')
+	testImplementation platform('org.junit:junit-bom:5.14.4')
 	testImplementation 'org.junit.jupiter:junit-jupiter'
+	testRuntimeOnly 'org.junit.platform:junit-platform-engine'
+	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
 	// 以下のJDBCドライバはテナント作成ツール(runTenantBatchタスク)の実行に必要となります。
 	// 実行する場合は使用するJDBCドライバのコメントアウトを外してください。


### PR DESCRIPTION
closes #45 

### 対応内容
- org.junit:junit-bom 5.10.2 -> 5.14.4
- testRuntimeOnly として org.junit.platform:junit-platform-engine を追加
- testRuntimeOnly として org.junit.platform:junit-platform-launcher を追加