### PR TITLE
ページネーションの遷移不具合を修正

### DIFF
--- a/src/main/vue/components/news/NewInfo.vue
+++ b/src/main/vue/components/news/NewInfo.vue
@@ -66,14 +66,9 @@ export default {
     this.loadContent()
     next()
   },
-  props: {
-    page: {
-      type: Number,
-      default: 0
-    }
-  },
   data() {
     return {
+      page: 0,
       pagination: {},
       newsInfoList: []
     }
@@ -87,6 +82,7 @@ export default {
     }
   },
   created() {
+    this.page = this.$route.query.page
     this.loadContent()
   },
   methods: {

--- a/src/main/vue/components/product/Category.vue
+++ b/src/main/vue/components/product/Category.vue
@@ -94,7 +94,6 @@
         <!-- ページング -->
         <pagination
           v-bind="{ pagination: pagination, paginationUrl: paginationUrl }"
-          :id="page"
         ></pagination>
       </div>
     </div>
@@ -118,6 +117,8 @@ export default {
   },
   data() {
     return {
+      page: 0,
+      categoryId: "",
       categoryName: '',
       categoryList: [],
       productList: [],

--- a/src/main/vue/components/ui/Pagination.vue
+++ b/src/main/vue/components/ui/Pagination.vue
@@ -34,7 +34,7 @@
         <router-link
           v-else
           class="page-link border-0 text-dark"
-          :to="{ path: paginationUrl + (currentPage - 1) }"
+          :to="pageTo(currentPage - 1)"
           aria-label="Previous"
         >
           <span aria-hidden="true">&laquo;{{ $t('samples.ec01.all.pagination.prev') }}</span>
@@ -47,7 +47,7 @@
           <a class="page-link border-0 text-dark bg-light">{{ i + 1 }}</a>
         </li>
         <li v-else-if="i < 3 || i > totalPage - 3" :key="'normal-' + i" class="page-item">
-          <router-link class="page-link border-0 text-dark" :to="{ path: paginationUrl + i }">
+          <router-link class="page-link border-0 text-dark" :to="pageTo(i)">
             {{ i + 1 }}
           </router-link>
         </li>
@@ -68,7 +68,7 @@
         <router-link
           v-else
           class="page-link border-0 text-dark"
-          :to="{ path: paginationUrl + (currentPage + 1) }"
+          :to="pageTo(currentPage + 1)"
           aria-label="Next"
         >
           <span aria-hidden="true">{{ $t('samples.ec01.all.pagination.next') }}</span>
@@ -98,6 +98,28 @@ export default {
     },
     totalPage() {
       return this.pagination === undefined ? 0 : this.pagination.totalPage
+    },
+    linkBase() {
+      const [path, search] = this.paginationUrl.split('?')
+      const params = new URLSearchParams(search || '')
+      const query = {}
+      params.forEach((value, key) => {
+        if (key !== 'page') {
+          query[key] = value
+        }
+      })
+      return { path, query }
+    }
+  },
+  methods: {
+    pageTo(page) {
+      return {
+        path: this.linkBase.path,
+        query: {
+          ...this.linkBase.query,
+          page: String(page)
+        }
+      }
     }
   }
 }

--- a/src/main/vue/mixins/Consts.js
+++ b/src/main/vue/mixins/Consts.js
@@ -63,7 +63,7 @@ export const Consts = {
       }
     },
     categoryUrl(categoryId) {
-      return this.path.category + categoryId + '&page='
+      return this.path.category + categoryId
     },
     newInfoUrl() {
       return this.path.newInfo

--- a/src/main/vue/mixins/Consts.js
+++ b/src/main/vue/mixins/Consts.js
@@ -25,7 +25,7 @@ export const Consts = {
       path: {
         productImg: tcPath + '/samples/ec01/resource/bin?type=productImg&id=',
         category: '/product/category?categoryId=',
-        newInfo: '/news/newInfo?page='
+        newInfo: '/news/newInfo'
       },
       apiPath: {
         defaultLayout: tcPath + '/api/samples/ec01/layout/defaultLayout',

--- a/src/main/vue/router/index.js
+++ b/src/main/vue/router/index.js
@@ -54,7 +54,7 @@ const router = createRouter({
           path: 'news/newInfo',
           name: 'newInfo',
           component: NewInfo,
-          props: (route) => ({ page: route.query.pageId })
+          props: true
         },
         { path: 'product/detail', name: 'detail', component: Detail, props: true },
         { path: 'product/category', name: 'category', component: Category, props: true },


### PR DESCRIPTION
## 事象
- ページ遷移ボタン（ページ番号・前へ・次へ）が正常に動作しなかった
- ページ番号を含む URL に直接アクセスしても、該当ページが表示されなかった
## 原因

### 1. `router-link` の `to` で path と query を文字列連結していたため

`Pagination.vue` で `paginationUrl + ページ番号` と文字列連結していたため、`router-link` の `to` プロパティに渡される `query` が無視されていた。

```js
// 修正前
:to="{ path: paginationUrl + (currentPage - 1) }"
```

`categoryId` のカテゴリを表すクエリと `page` のページ番号を表すクエリを正しく扱えない設計になっていた。

### 2. props の `page` に代入していた（Vue 非推奨・禁止パターン）ため

ニュース・カテゴリで `page` を props 経由で受け取り、`beforeRouteUpdate` 等で props へ直接代入していた。

```js
// 修正前
this.page = to.query.page
```

- Vue 2 でも props への直接代入は非推奨
- Vue 3 では完全に禁止

ページ遷移時にエラーとなり、状態更新も正しく行われなかった。  
また `page` / `pageId` のクエリのキー名もルーター定義と不整合だった。

## 修正方針

1. `Pagination.vue` の router-link にて、 path, queryを分けて指定する。
2. props への代入をやめ、`data()` で定義した `page` に `$route.query.page` を代入する。クエリのpageIdの命名はpageに統一する。


## 影響範囲
ページネーション機能を有する以下のページ:
- ニュース一覧（`/news/newInfo`）
- カテゴリ商品一覧（`/product/category?categoryId=xxx`）


## テスト項目
### ニュースページ 
- [x] ページ番号ボタンをクリックして画面遷移できる
- [x] 「次へ」、「前へ」ボタンをクリックして画面遷移できる
- [x] URL直打ちで特定のページに遷移できる
### カテゴリページ
- [x] ページ番号ボタンをクリックして画面遷移できる
- [x] 「次へ」、「前へ」ボタンをクリックして画面遷移できる
- [x] URL直打ちで特定のページに遷移できる

## 修正後のデモ

<img width="1406" height="878" alt="iplass_pagination" src="https://github.com/user-attachments/assets/b9dbd8c5-9a10-437d-b27d-ff6f85ab42df" />
